### PR TITLE
Fix url for redis service documentation

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -52,7 +52,7 @@ func (redisServiceBroker *RedisServiceBroker) Services() []brokerapi.Service {
 			Metadata: brokerapi.ServiceMetadata{
 				DisplayName:      "Redis",
 				LongDescription:  "",
-				DocumentationUrl: "http://docs.pivotal.io/p1-services/Redis.html",
+				DocumentationUrl: "http://docs.pivotal.io/redis/index.html",
 				SupportUrl:       "http://support.pivotal.io",
 				Listing: brokerapi.ServiceMetadataListing{
 					Blurb:    "",


### PR DESCRIPTION
This PR replaces the currently dead link, with the correct url for the Redis Service documentation.