### PR TITLE
Enable controlling the shared instance port range

### DIFF
--- a/brokerconfig/assets/test_config.yml
+++ b/brokerconfig/assets/test_config.yml
@@ -12,6 +12,8 @@ redis:
   process_check_interval: 5
   start_redis_timeout: 3
   service_instance_limit: 3
+  shared_max_port: 65535
+  shared_min_port: 1024
   backup:
     endpoint_url: http://s3url.com
     bucket_name: redis-backups

--- a/brokerconfig/assets/test_config.yml-backup-minimum
+++ b/brokerconfig/assets/test_config.yml-backup-minimum
@@ -11,6 +11,8 @@ redis:
   process_check_interval: 5
   start_redis_timeout: 3
   service_instance_limit: 3
+  shared_max_port: 65535
+  shared_min_port: 1024
   backup:
     endpoint_url: http://s3url.com
     bucket_name: redis-backups

--- a/brokerconfig/assets/test_config.yml-invalid
+++ b/brokerconfig/assets/test_config.yml-invalid
@@ -6,6 +6,8 @@ redis:
   redis_conf_path: /path/to/redis/config.conf
   process_check_interval: 5
   service_instance_limit: 3
+  shared_max_port: 65535
+  shared_min_port: 1024
   backup:
     endpoint_url: http://s3url.com
     bucket_name: redis-backups

--- a/brokerconfig/assets/test_config.yml-no-backup
+++ b/brokerconfig/assets/test_config.yml-no-backup
@@ -11,6 +11,8 @@ redis:
   process_check_interval: 5
   start_redis_timeout: 3
   service_instance_limit: 3
+  shared_max_port: 65535
+  shared_min_port: 1024
   dedicated:
     nodes:
       - 10.0.0.1

--- a/brokerintegration/assets/broker.yml
+++ b/brokerintegration/assets/broker.yml
@@ -15,6 +15,8 @@ redis:
   support_url: http://support.pivotal.io
   display_name: Redis
   description: Redis service to provide a key-value store
+  shared_max_port: 65535
+  shared_min_port: 1024
   dedicated:
     nodes:
     - server1.lvh.me

--- a/brokerintegration/assets/broker.yml-colocated
+++ b/brokerintegration/assets/broker.yml-colocated
@@ -15,6 +15,8 @@ redis:
   support_url: http://support.pivotal.io
   display_name: Redis
   description: Redis service to provide a key-value store
+  shared_max_port: 65535
+  shared_min_port: 1024
   dedicated:
     nodes:
     - server1.lvh.me

--- a/brokerintegration/assets/broker.yml-consistency
+++ b/brokerintegration/assets/broker.yml-consistency
@@ -15,6 +15,8 @@ redis:
   support_url: http://support.pivotal.io
   display_name: Redis
   description: Redis service to provide a key-value store
+  shared_max_port: 65535
+  shared_min_port: 1024
   dedicated:
     nodes:
     - server1.127.0.0.1.xip.io

--- a/brokerintegration/assets/broker.yml-extra-node
+++ b/brokerintegration/assets/broker.yml-extra-node
@@ -9,6 +9,8 @@
   pidfile_directory: /tmp/pidfiles
   "log_directory": "/tmp/redis-log-dir"
   "service_instance_limit": 3
+  "shared_max_port": 65535
+  "shared_min_port": 1024
   "dedicated":
     "nodes":
     - server1.lvh.me

--- a/brokerintegration/assets/broker.yml-no-dedicated
+++ b/brokerintegration/assets/broker.yml-no-dedicated
@@ -9,6 +9,8 @@
   pidfile_directory: /tmp/pidfiles
   "log_directory": "/tmp/redis-log-dir"
   "service_instance_limit": 3
+  "shared_max_port": 65535
+  "shared_min_port": 1024
   "dedicated":
     "nodes": []
     "statefile_path": "/tmp/redis-config-dir/statefile.json"

--- a/brokerintegration/assets/broker.yml-no-shared
+++ b/brokerintegration/assets/broker.yml-no-shared
@@ -9,6 +9,8 @@
   pidfile_directory: /tmp/pidfiles
   "log_directory": "/tmp/redis-log-dir"
   "service_instance_limit": 0
+  "shared_max_port": 65535
+  "shared_min_port": 1024
   "dedicated":
     "nodes":
     - server1.lvh.me

--- a/brokerintegration/assets/broker.yml-one-dedicated
+++ b/brokerintegration/assets/broker.yml-one-dedicated
@@ -9,6 +9,8 @@
   pidfile_directory: /tmp/pidfiles
   "log_directory": "/tmp/redis-log-dir"
   "service_instance_limit": 3
+  "shared_max_port": 65535
+  "shared_min_port": 1024
   "dedicated":
     "nodes":
     - "127.0.0.1"

--- a/brokerintegration/assets/broker.yml.updated_maxmemory
+++ b/brokerintegration/assets/broker.yml.updated_maxmemory
@@ -10,6 +10,8 @@ redis:
   process_check_interval: 1
   start_redis_timeout: 3
   service_instance_limit: 3
+  shared_max_port: 65535
+  shared_min_port: 1024
   dedicated:
     nodes: []
     statefile_path: /tmp/redis-config-dir/statefile.json

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -59,7 +59,7 @@ func main() {
 	}
 
 	localCreator := &redis.LocalInstanceCreator{
-		FindFreePort:            system.FindFreePort,
+		FreeTcpPort:     system.NewFreeTcpPort(),
 		RedisConfiguration:      config.RedisConfiguration,
 		ProcessController:       processController,
 		LocalInstanceRepository: localRepo,

--- a/configmigratorintegration/assets/broker.yml
+++ b/configmigratorintegration/assets/broker.yml
@@ -10,6 +10,8 @@ redis:
   data_directory: /tmp/redis-data-dir
   log_directory: /tmp/redis-log-dir
   service_instance_limit: 3
+  shared_max_port: 65535
+  shared_min_port: 1024
   dedicated:
     nodes:
     - server1.lvh.me

--- a/redis/local_instance_creator_test.go
+++ b/redis/local_instance_creator_test.go
@@ -12,14 +12,10 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/pivotal-cf/cf-redis-broker/system"
 )
 
 var freePortsFound int
-
-func fakeFreePortFinder() (int, error) {
-	freePortsFound++
-	return 8080, nil
-}
 
 var _ = Describe("Local Redis Creator", func() {
 
@@ -30,12 +26,15 @@ var _ = Describe("Local Redis Creator", func() {
 
 	BeforeEach(func() {
 		instanceID = uuid.NewRandom().String()
+		freeTcpPort := &system.FakeFreeTcpPort{Cb: func() {
+			freePortsFound++
+		}}
 		fakeProcessController = &fakes.FakeProcessController{}
 
 		fakeLocalRepository = new(fakes.FakeLocalRepository)
 
 		localInstanceCreator = &redis.LocalInstanceCreator{
-			FindFreePort:            fakeFreePortFinder,
+			FreeTcpPort:     freeTcpPort,
 			ProcessController:       fakeProcessController,
 			LocalInstanceRepository: fakeLocalRepository,
 			RedisConfiguration: brokerconfig.ServiceConfiguration{

--- a/system/fake_free_tcp_port.go
+++ b/system/fake_free_tcp_port.go
@@ -1,0 +1,11 @@
+package system
+
+type FakeFreeTcpPort struct {
+	FreeTcpPort
+	Cb func()
+}
+
+func (f *FakeFreeTcpPort) FindFreePortInRange(minport int, maxport int) (int, error) {
+	f.Cb()
+	return 8080, nil
+}

--- a/system/free_tcp_port.go
+++ b/system/free_tcp_port.go
@@ -3,16 +3,40 @@ package system
 import (
 	"net"
 	"strconv"
+	"errors"
 )
 
-func FindFreePort() (int, error) {
-	l, _ := net.Listen("tcp", ":0")
-	defer l.Close()
+const (
+	MIN_ACCEPTED_PORT int = 1024
+	MAX_ACCEPTED_PORT int = 65535
+)
 
-	parsedPort, parseErr := strconv.ParseInt(l.Addr().String()[5:], 10, 32)
-	if parseErr != nil {
-		return -1, parseErr
+type FreeTcpPort interface {
+	FindFreePortInRange(minport int, maxport int) (int, error)
+}
+type FreeRangeTcpPort struct {
+	FreeTcpPort
+	IsPortAvailable func(num int) bool
+}
+
+func NewFreeTcpPort() FreeTcpPort {
+	return &FreeRangeTcpPort{IsPortAvailable: isPortAvailable}
+}
+func isPortAvailable(num int) bool {
+	l, err := net.Listen("tcp", ":" + strconv.Itoa(num))
+	if err != nil {
+		return false
 	}
-
-	return int(parsedPort), nil
+	l.Close()
+	return true
+}
+func (f FreeRangeTcpPort) FindFreePortInRange(minport int, maxport int) (int, error) {
+	port := minport
+	for port <= maxport {
+		if f.IsPortAvailable(port) {
+			return port, nil
+		}
+		port++
+	}
+	return -1, errors.New("No port is available in the range. Please ask help to your Operator")
 }

--- a/system/free_tcp_port_test.go
+++ b/system/free_tcp_port_test.go
@@ -1,28 +1,52 @@
 package system_test
 
 import (
-	"net"
-	"regexp"
-	"strconv"
-
-	"github.com/pivotal-cf/cf-redis-broker/system"
+	. "github.com/pivotal-cf/cf-redis-broker/system"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Next available TCP port", func() {
+var _ = Describe("Find next available TCP port in a range", func() {
+	var freeTcpPort FreeTcpPort
+	BeforeEach(func() {
+		freeTcpPort = NewFreeTcpPort()
+	})
+	Context("with a valid range", func() {
+		It("should give a free port", func() {
+			port, err := freeTcpPort.FindFreePortInRange(40000, 40005)
+			Expect(err).ShouldNot(HaveOccurred())
 
-	It("finds a free TCP port", func() {
-		port, _ := system.FindFreePort()
-		portStr := strconv.Itoa(port)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(port).To(BeNumerically(">=", 40000))
+			Expect(port).To(BeNumerically("<=", 40005))
+		})
+		It("should give the only free port if the the minimum port is equals to maximum port", func() {
+			freeTcpPort = NewFreeTcpPort()
+			freeTcpPort.(*FreeRangeTcpPort).IsPortAvailable = func(num int) bool {
+				return true
+			}
 
-		matched, err := regexp.MatchString("^[0-9]+$", portStr)
-		Ω(matched).To(Equal(true))
+			port, err := freeTcpPort.FindFreePortInRange(65000, 65000)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(err).ShouldNot(HaveOccurred())
 
-		l, err := net.Listen("tcp", ":"+portStr)
-		Ω(err).ToNot(HaveOccurred())
-		l.Close()
+			Expect(port).To(BeEquivalentTo(65000))
+		})
+	})
+	Context("When no port is available in range", func() {
+		BeforeEach(func() {
+			freeTcpPort = NewFreeTcpPort()
+			freeTcpPort.(*FreeRangeTcpPort).IsPortAvailable = func(num int) bool {
+				return false
+			}
+		})
+		It("Should return an error", func() {
+			_, err := freeTcpPort.FindFreePortInRange(40000, 40005)
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("No port is available in the range"))
+		})
 	})
 
 })
+


### PR DESCRIPTION
As documented in https://github.com/pivotal-cf/cf-redis-release/issues/36, this PR enables control the shared instance port used within a preferred range.

- during configuration loading if ports are misconfigured it will report directly report the error. 
- When the service broker try to find a free port during provisioning and no port is available in the range it will give a service broker error. This error will ask to the user to contact his operator.

Regarding unit tests and integrations run as part of this PR: 
- integration tests were run with the docker image provided. I get some errors in this usecase, when a test want to check that program failed when a directory is not writeable it doesn't failed because on docker user privileged are root and this user is permitted to write on a folder which is not. Example: https://github.com/orange-cloudfoundry/cf-redis-broker/blob/shared-instance-ports-broker-prepation/brokerintegration/development_instance_provisioning_test.go#L127-L138
- all other tests look good. 