### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/consistency/instances_provider.go
+++ b/consistency/instances_provider.go
@@ -19,7 +19,7 @@ func NewStateFileAvailableInstances(path string) *stateFileAvailableInstances {
 	return &stateFileAvailableInstances{path}
 }
 
-// AvailableInstances reads and returns the available instances from the state file.
+// Instances reads and returns the available instances from the state file.
 func (s *stateFileAvailableInstances) Instances() ([]redis.Instance, error) {
 	reader, err := os.Open(s.path)
 	if err != nil {


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?